### PR TITLE
Do not try to automatically update openshift/api

### DIFF
--- a/default.json
+++ b/default.json
@@ -37,6 +37,14 @@
       "allowedVersions": "< 0.15.0",
       "enabled": true
     },
+    // We need to manually select a version to bump to as there
+    // are no tags in the repo and we are not compatible with
+    // the master branch yet
+    {
+      "groupName": "openshift",
+      "matchPackageNames": ["github.com/openshift/api"],
+      "enabled": false
+    },
     {
       "groupName": "mergo",
       "matchPackagePatterns": ["^github.com/imdario/mergo"],


### PR DESCRIPTION
There are not tags in openshift/api to track and we are not yet compatible with the master branch.

This disables trying to update the dep to save CI resources as we know that bumping to master does not work.