### PR TITLE
[renovate]Do not follow k8s.io/utils

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -43,6 +43,14 @@
       "matchPackageNames": ["k8s.io/kube-openapi"],
       "enabled": false
     },
+    // We disable k8s.io/utils updates as it has no tags to express a limit
+    // due to other k8s.io packages. So we rely on bumping this transitively
+    // when other k8s.io package versions are bumped and require newer utils
+    {
+      "groupName": "k8s.io/utils",
+      "matchPackageNames": ["k8s.io/utils"],
+      "enabled": false
+    },
     // We disable golang.org/x/exp updates as it has no tags causing a bump
     // for each commit which is too frequent. So instead we will rely on
     // bumping this transitively when other packages require them.


### PR DESCRIPTION
This module has no semantic version tags and following pseudoversions
are expensive and sometimes[1] dangerous. So this commit disables
the automatic update of this module and instead we rely on bumping this
when other k8s.io modules transitively require them.

[1]https://github.com/kubernetes/utils/pull/317
