### PR TITLE
Pin github.com/metallb/frr-k8s < 0.0.12

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -133,6 +133,13 @@
       // 0.8.0 needs golang 1.22
       "allowedVersions": "< 0.8.0",
       "enabled": true
+    },
+    {
+      "groupName": "metallb",
+      "matchPackagePatterns": ["^github.com/metallb/frr-k8s"],
+      // 0.0.12 needs golang 1.22
+      "allowedVersions": "< 0.0.12",
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
0.0.12 and later requires golang 1.22. The infra-operator imports this and results in the expected failures.