### PR TITLE
Update dependencies for golang, OCP4.18 and rabbitmq-cluster-operator bump

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -9,7 +9,7 @@
   "enabledManagers": ["gomod"],
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.21"
+    "go": "1.24"
   },
   "schedule":[
     "every weekend"
@@ -31,8 +31,8 @@
       "matchPackagePatterns": ["^k8s.io"],
       // We exclude kube-openapi as it has no tags
       "excludePackagePatterns": ["^k8s.io/kube-openapi"],
-      // 0.30 needs controller-runtime 0.18 and golang 1.22
-      "allowedVersions": "< 0.30.0",
+      // Allow k8s.io v0.31.x for OCP 4.18
+      "allowedVersions": "< 0.32.0",
       "enabled": true
     },
     // We disable kube-openapi updates as it has no tags to express a limit
@@ -62,8 +62,8 @@
     {
       "groupName": "sigs.k8s.io/controller-runtime",
       "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime"],
-      // 0.18 needs golang 1.22 and ubi9/go-toolset:1.22
-      "allowedVersions": "< 0.18.0",
+      // Allow controller-runtime v0.19.x for OCP 4.18
+      "allowedVersions": "< 0.20.0",
       "enabled": true
     },
     // We need to manually select a version to bump to as there
@@ -92,28 +92,31 @@
       "allowedVersions": "<= 1.8.0",
       "enabled": true
     },
-    {
-      "groupName": "ginkgo",
-      "matchPackagePatterns": ["^github.com/onsi/ginkgo/v2"],
-      // 2.20.2 requires golang 1.22
-      "allowedVersions": "< 2.20.2",
-      "enabled": true
-    },
-    {
-      "groupName": "gomega",
-      "matchPackagePatterns": ["^github.com/onsi/gomega"],
-      // 1.34.2 requires golang 1.22
-      "allowedVersions": "< 1.34.2",
-      "enabled": true
-    },
+    // mschuppert - remove pinning of ginkgo after bump to golang 1.24, but keeping it as reference for future need
+    //{
+    //  "groupName": "ginkgo",
+    //  "matchPackagePatterns": ["^github.com/onsi/ginkgo/v2"],
+    //  // 2.20.2 requires golang 1.22
+    //  "allowedVersions": "< 2.20.2",
+    //  "enabled": true
+    //},
+    // mschuppert - remove pinning of gomega after bump to golang 1.24, but keeping it as reference for future need
+    //{
+    //  "groupName": "gomega",
+    //  "matchPackagePatterns": ["^github.com/onsi/gomega"],
+    //  // 1.34.2 requires golang 1.22
+    //  "allowedVersions": "< 1.34.2",
+    //  "enabled": true
+    //},
     {
       "groupName": "cert-manager",
       "matchPackagePatterns": ["^github.com/cert-manager/cert-manager"],
-      // 1.15 needs golang 1.22
-      "allowedVersions": "< 1.15.0",
+      // Allow 1.17 for OCP 4.18 https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-operator-release-notes-1-17-0_cert-manager-operator-release-notes
+      "allowedVersions": "< 1.18.0",
       "enabled": true
     },
     {
+      // mschuppert - bump of gophercloud is planned
       "groupName": "gophercloud",
       "matchPackagePatterns": ["^github.com/gophercloud/gophercloud"],
       // 2.0.0 requires golang 1.22
@@ -123,36 +126,38 @@
     {
       "groupName": "operator-framework-api",
       "matchPackagePatterns": ["^github.com/operator-framework/api"],
-      // 0.24.0 needs golang 1.22
-      "allowedVersions": "< 0.24.0",
+      // Allow 0.27.0 for OCP 4.18 https://github.com/openshift/operator-framework-olm/blob/release-4.18/go.mod#L16
+      "allowedVersions": "< 0.28.0",
       "enabled": true
     },
     {
       "groupName": "baremetal-operator",
       "matchPackagePatterns": ["^github.com/metal3-io/baremetal-operator/apis"],
       // 0.8.0 needs golang 1.22
+      // mschuppert - from https://github.com/openshift/baremetal-operator/blob/release-4.18/go.mod#L9 still 0.5.1 on OCP 4.18
       "allowedVersions": "< 0.8.0",
       "enabled": true
     },
     {
       "groupName": "metallb",
       "matchPackagePatterns": ["^github.com/metallb/frr-k8s"],
-      // 0.0.12 needs golang 1.22
-      "allowedVersions": "< 0.0.12",
+      // Allow 0.0.15 for OCP 4.18 https://github.com/openshift/metallb/blob/release-4.18/go.mod#L15
+      "allowedVersions": "< 0.0.19",
       "enabled": true
     },
-    {
-      "groupName": "crypto",
-      "matchPackagePatterns": ["^golang.org/x/crypto"],
-      // 0.34.0 needs golang 1.23
-      "allowedVersions": "< 0.34.0",
-      "enabled": true
-    },
+    // mschuppert - remove pinning of crypto after bump to golang 1.24, but keeping it as reference for future need
+    //{
+    //  "groupName": "crypto",
+    //  "matchPackagePatterns": ["^golang.org/x/crypto"],
+    //  // 0.34.0 needs golang 1.23
+    //  "allowedVersions": "< 0.34.0",
+    //  "enabled": true
+    //},
     {
       "groupName": "rabbitmq-cluster-operator",
       "matchPackagePatterns": ["^github.com/rabbitmq/cluster-operator/v2"],
-      // 2.10.0 needs golang 1.22
-      "allowedVersions": "< 2.10.0",
+      // Allow 2.16 bumped in https://github.com/openstack-k8s-operators/infra-operator/pull/441
+      "allowedVersions": "< 2.17.0",
       "enabled": true
     }
   ]


### PR DESCRIPTION
* go 1.24
* k8s.io < 0.32.0
* controller-runtime < 0.20.0
* cert-manager < 1.18.0
* github.com/operator-framework/api < 0.28.0
* github.com/metallb/frr-k8s < 0.0.19
* github.com/rabbitmq/cluster-operator/v2 < 2.17.0

Jira: OSPRH-12935