### PR TITLE
Pin cert-manager cmtl to specific pseudo version

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -57,7 +57,7 @@
       ],
       "matchDepTypes": ["replace"],
       "groupName": "cmctl 2.1.2 replaces",
-      "allowedVersions": "< 2.2.0"
+      "allowedVersions": "2.1.2-0.20241127223932-88edb96860cf"
     },
     // We disable kube-openapi updates as it has no tags to express a limit
     // due to other k8s.io packages. So we rely on bumping this transitively


### PR DESCRIPTION
The commit we currently pin to is not a release and therefore bumps get still proposed. Lets make sure we pin for now to the current pseudo version.