### PR TITLE
Disable digest for cert-manager cmctl

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -57,7 +57,10 @@
       ],
       "matchDepTypes": ["replace"],
       "groupName": "cmctl 2.1.2 replaces",
-      "allowedVersions": "2.1.2-0.20241127223932-88edb96860cf"
+      "allowedVersions": "2.1.2-0.20241127223932-88edb96860cf",
+      "digest": {
+        "enabled": false
+      }
     },
     // We disable kube-openapi updates as it has no tags to express a limit
     // due to other k8s.io packages. So we rely on bumping this transitively


### PR DESCRIPTION
renovate still bumps cmctl to the latest digest:
chore(deps): update github.com/cert-manager/cmctl/v2 digest to b753872

```
    {
      "datasource": "go",
      "depType": "replace",
      "depName": "github.com/cert-manager/cmctl/v2",
      "currentValue": "v2.1.2-0.20241127223932-88edb96860cf",
      "currentDigest": "88edb96860cf",
      "digestOneAndOnly": true,
      "versioning": "loose",
      "managerData": {"lineNumber": 155},
      "updates": [
        {
          "updateType": "digest",
          "newValue": "v2.1.2-0.20241127223932-88edb96860cf",
          "newDigest": "b75387282a73dc7473903a6e9e527bdd2e6cd40f",
          "branchName": "renovate/cmctl-2.1.2-replaces"
        }
      ],
      "packageName": "github.com/cert-manager/cmctl/v2",
      "warnings": [],
      "sourceUrl": "https://github.com/cert-manager/cmctl",
      "mostRecentTimestamp": "2025-07-11T11:58:30.000Z",
      "currentVersion": "v2.1.2-0.20241127223932-88edb96860cf",
      "fixedVersion": "v2.1.2-0.20241127223932-88edb96860cf"
    }
```

lets disable digest for this depenency to not bump the digest.