### PR TITLE
Pin gomega < 1.42.1 and group GitHub Actions bumps

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -33,6 +33,11 @@
       "enabled": false
     },
     {
+      // Group all allowed GitHub Action workflow bumps into one PR
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions Dependencies"
+    },
+    {
       "groupName": "openstack-k8s-operators",
       "matchPackagePatterns": ["^github.com/openstack-k8s-operators"],
       // force pseudo versioning
@@ -139,14 +144,13 @@
       "allowedVersions": "< 2.28.3",
       "enabled": true
     },
-    // mschuppert - remove pinning of gomega after bump to golang 1.24, but keeping it as reference for future need
-    //{
-    //  "groupName": "gomega",
-    //  "matchPackagePatterns": ["^github.com/onsi/gomega"],
-    //  // 1.34.2 requires golang 1.22
-    //  "allowedVersions": "< 1.34.2",
-    //  "enabled": true
-    //},
+    {
+      "groupName": "gomega",
+      "matchPackagePatterns": ["^github.com/onsi/gomega"],
+      // gomega 1.42.1+ requires Go 1.25
+      "allowedVersions": "< 1.42.1",
+      "enabled": true
+    },
     {
       "groupName": "cert-manager",
       "matchPackagePatterns": ["^github.com/cert-manager/cert-manager"],


### PR DESCRIPTION
Pin gomega to < 1.42.1 as 1.42.1+ requires Go 1.25. Group all GitHub Actions dependency bumps into a single PR per repo.

Jira: OSPRH-31856