### PR TITLE
Disable postUpgradeTasks for github-actions manager

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -38,6 +38,16 @@
       "groupName": "GitHub Actions Dependencies"
     },
     {
+      // Disable postUpgradeTasks for github-actions — repos define tasks like
+      // "make gowork" / "make tidy" that require Go, which Renovate only
+      // provisions for the gomod manager
+      "matchManagers": ["github-actions"],
+      "postUpgradeTasks": {
+        "commands": [],
+        "executionMode": "update"
+      }
+    },
+    {
       "groupName": "openstack-k8s-operators",
       "matchPackagePatterns": ["^github.com/openstack-k8s-operators"],
       // force pseudo versioning


### PR DESCRIPTION
Repos define postUpgradeTasks like "make gowork" and "make tidy" that require Go. Renovate only provisions Go for the gomod manager, so these commands fail with "go: command not found" on github-actions PRs.

Jira: OSPRH-31856