### PR TITLE
Pin Ruby to < 4.0 in GitHub Actions bumps

### DIFF
--- a/18-stable.json5
+++ b/18-stable.json5
@@ -34,6 +34,12 @@
       "enabled": false
     },
     {
+      // Ruby 4.0 removed bundled gems (logger, etc.) breaking asciidoc docs builds
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["ruby"],
+      "allowedVersions": "< 4.0.0"
+    },
+    {
       // Group all allowed GitHub Action workflow bumps into one PR
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions Dependencies"

--- a/default.json5
+++ b/default.json5
@@ -34,6 +34,12 @@
       "enabled": false
     },
     {
+      // Ruby 4.0 removed bundled gems (logger, etc.) breaking asciidoc docs builds
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["ruby"],
+      "allowedVersions": "< 4.0.0"
+    },
+    {
       // Group all allowed GitHub Action workflow bumps into one PR
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions Dependencies"


### PR DESCRIPTION
Ruby 4.0 removed bundled gems (logger, etc.) from the standard library, breaking asciidoc docs builds that depend on asciidoctor.